### PR TITLE
[Feat] 에러 핸들러 구현

### DIFF
--- a/salgulok/src/main/java/com/salgulok/global/exception/ErrorCode.java
+++ b/salgulok/src/main/java/com/salgulok/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.salgulok.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // Default
+    ERROR(400, "요청 처리에 실패했습니다."),
+    UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다."),
+
+    // auth
+    KAKAO_LOGIN_ERROR(401, "카카오 로그인 인증에 실패했습니다."),
+    REFRESH_TOKEN_EMPTY(400, "리프레시 토큰이 존재하지 않습니다."),
+    ACCESS_TOKEN_EMPTY(401, "엑세스 토큰이 존재하지 않습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/salgulok/src/main/java/com/salgulok/global/exception/GlobalExceptionHandler.java
+++ b/salgulok/src/main/java/com/salgulok/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package com.salgulok.global.exception;
+
+import com.salgulok.global.exception.dto.ErrorDto;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SalgulokException.class)
+    protected ResponseEntity<ErrorDto> handleCustomException(SalgulokException e, HttpServletRequest request) {
+        ErrorDto errorDto = new ErrorDto(
+                LocalDateTime.now().toString(),
+                e.getErrorCode().getStatus(),
+                e.getErrorCode().name(),
+                e.getErrorCode().getMessage(),
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorDto, HttpStatusCode.valueOf(e.getErrorCode().getStatus()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorDto> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())    // "필드명: 메세지" 형식으로 변환
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+
+        ErrorDto errorDto = new ErrorDto(
+                LocalDateTime.now().toString(),
+                400,
+                "INVALID_INPUT",
+                errorMessage,
+                request.getRequestURI()
+        );
+        return new ResponseEntity<>(errorDto, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/salgulok/src/main/java/com/salgulok/global/exception/SalgulokException.java
+++ b/salgulok/src/main/java/com/salgulok/global/exception/SalgulokException.java
@@ -1,0 +1,10 @@
+package com.salgulok.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SalgulokException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/salgulok/src/main/java/com/salgulok/global/exception/dto/ErrorDto.java
+++ b/salgulok/src/main/java/com/salgulok/global/exception/dto/ErrorDto.java
@@ -1,0 +1,9 @@
+package com.salgulok.global.exception.dto;
+
+public record ErrorDto(
+        String timestamp,
+        int status,
+        String errorCode,
+        String message,
+        String path
+) {}


### PR DESCRIPTION
## 🍑 작업 개요
- 에러 핸들러 구현

## 🔍 참고 사항
- 에러 던질 때 `global/exception/ErrorCode`에서 원하는 에러 코드 생성 후에,
```
new SalgulokException(ErrorCode.KAKAO_LOGIN_ERROR)); 
```
이런 방식으로 에러 처리 해주시면 됩니다!

## 🔗 관련 이슈
- closes #4 
