### PR TITLE
[Fix] 로그인 시 닉네임 정보 없는 경우 isNewUser true로 설정

### DIFF
--- a/salgulok/src/main/java/com/salgulok/auth/service/AuthService.java
+++ b/salgulok/src/main/java/com/salgulok/auth/service/AuthService.java
@@ -47,6 +47,10 @@ public class AuthService {
             user = userRepository.save(User.builder()
                     .kakaoId(kakaoId)
                     .build());
+        } else {
+            if (user.getUsername() == null){
+                isNewUser = true;
+            }
         }
 
         String accessToken = createTokens(user, response);
@@ -102,7 +106,7 @@ public class AuthService {
     private Cookie createRefreshTokenCookie(String refreshToken){
         Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
         refreshCookie.setHttpOnly(true);    // JS에서 접근 불가
-        refreshCookie.setSecure(false);      // HTTPS 전용
+        refreshCookie.setSecure(true);      // HTTPS 전용
         refreshCookie.setPath("/");
         refreshCookie.setMaxAge(jwtUtils.getRefreshTokenSeconds());
 


### PR DESCRIPTION
## 🍑 작업 개요
- 로그인 시 닉네임 정보 없는 경우 추가 회원정보 입력창으로 넘어가도록 isNewUser true로 설정
