### PR TITLE
feat: Region Field Filtering Added in Post Field

### DIFF
--- a/salgulok/src/main/java/com/salgulok/community/controller/CommunityController.java
+++ b/salgulok/src/main/java/com/salgulok/community/controller/CommunityController.java
@@ -4,6 +4,7 @@ package com.salgulok.community.controller;
 import com.salgulok.community.domain.PostSearchCond;
 import com.salgulok.community.dto.request.CommentCreateRequest;
 import com.salgulok.community.dto.request.PostCreateRequest;
+import com.salgulok.community.dto.response.CommentResponse;
 import com.salgulok.community.dto.response.PostResponse;
 import com.salgulok.community.service.CommunityService;
 import jakarta.validation.Valid;
@@ -24,12 +25,13 @@ public class CommunityController {
     // 전체/지역/주제/체류여부 조합 조회
     @GetMapping("/posts")
     public Page<PostResponse> getPosts(
+            @RequestParam(required = false) Long regionId,
             @RequestParam(required = false) String region,
             @RequestParam(required = false) String topic,
             @RequestParam(required = false) String status,
             @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
     ) {
-        return communityService.searchPosts(new PostSearchCond(region, topic, status), pageable);
+        return communityService.searchPosts(new PostSearchCond(regionId, region, topic, status), pageable);
     }
 
     // 상세
@@ -66,4 +68,22 @@ public class CommunityController {
         communityService.deleteComment(postId, commentId);
         return ResponseEntity.noContent().build();
     }
+
+    // controller/CommunityController.java (추가 분)
+    @GetMapping("/posts/{postId}/comments")
+    public Page<CommentResponse> getComments(
+            @PathVariable Long postId,
+            @PageableDefault(size = 20, sort = "id") Pageable pageable
+    ) {
+        return communityService.getComments(postId, pageable);
+    }
+
+    @GetMapping("/posts/{postId}/comments/{commentId}")
+    public CommentResponse getComment(
+            @PathVariable Long postId,
+            @PathVariable Long commentId
+    ) {
+        return communityService.getComment(postId, commentId);
+    }
+
 }

--- a/salgulok/src/main/java/com/salgulok/community/domain/PostSearchCond.java
+++ b/salgulok/src/main/java/com/salgulok/community/domain/PostSearchCond.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class PostSearchCond {
+    private Long regionId;   // ★ 추가
     private String region;   // ex) "seoul" (Region.name 또는 code로 맞춰 비교)
     private String topic;    // Topic enum name 또는 소문자 문자열
     private String status;   // "STAYING" → User.isTraveling = true

--- a/salgulok/src/main/java/com/salgulok/community/dto/request/PostCreateRequest.java
+++ b/salgulok/src/main/java/com/salgulok/community/dto/request/PostCreateRequest.java
@@ -10,5 +10,6 @@ import lombok.Getter;
 public class PostCreateRequest {
     @NotNull private Topic topic;
     @NotBlank private String content;
+    @NotNull private Long regionId;
     @NotNull private Long authorId; // 로그인 처리했다면 Security에서 꺼내도 됨
 }

--- a/salgulok/src/main/java/com/salgulok/community/dto/response/CommentResponse.java
+++ b/salgulok/src/main/java/com/salgulok/community/dto/response/CommentResponse.java
@@ -9,13 +9,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CommentResponse {
     private Long id;
+    private Long authorId;
     private Long postId;
     private String username;
     private String content;
 
     public static CommentResponse from(Comment c) {
+        var user = c.getAuthor();
+
         return new CommentResponse(
                 c.getId(),
+                user.getUserId(),
                 c.getPost().getId(),
                 c.getAuthor().getUsername(),
                 c.getContent()

--- a/salgulok/src/main/java/com/salgulok/community/dto/response/PostResponse.java
+++ b/salgulok/src/main/java/com/salgulok/community/dto/response/PostResponse.java
@@ -1,30 +1,45 @@
 // dto/response/PostResponse.java
 package com.salgulok.community.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.salgulok.community.entity.Post;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 필드 응답에서 생략
 public class PostResponse {
     private Long id;
+    private Long authorId;           // ★ 추가
     private String username;
     private String region;        // Region 이름 또는 코드
     private String topic;
     private String content;
     private Boolean authorStaying;
+    private String authorProfileImg;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+
 
     public static PostResponse from(Post p) {
         var user = p.getAuthor();
         var regionName = user.getRegion() != null ? user.getRegion().getName() : null; // Region 엔티티에 맞게
+        String avatar = user.getProfileImg(); // 이미 절대 URL이면 그대로
+
         return new PostResponse(
                 p.getId(),
+                user.getUserId(),
                 user.getUsername(),
                 regionName,
                 p.getTopic() != null ? p.getTopic().name() : null,
                 p.getContent(),
-                Boolean.TRUE.equals(user.getIsTraveling())
+                Boolean.TRUE.equals(user.getIsTraveling()),
+                avatar,
+                p.getCreatedAt()
         );
     }
 }

--- a/salgulok/src/main/java/com/salgulok/community/entity/Comment.java
+++ b/salgulok/src/main/java/com/salgulok/community/entity/Comment.java
@@ -35,6 +35,8 @@ public class Comment {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+
+
     public Comment(Post post, User author, String content) {
         this.post = post;
         this.author = author;

--- a/salgulok/src/main/java/com/salgulok/community/entity/Post.java
+++ b/salgulok/src/main/java/com/salgulok/community/entity/Post.java
@@ -10,6 +10,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -27,6 +29,9 @@ public class Post {
     @JoinColumn(name = "author_id", nullable = false)
     private User author;
 
+    @Column(nullable = false)
+    private Long regionId; // regionId 필드 추가
+
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
     private Topic topic;
@@ -38,8 +43,12 @@ public class Post {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public Post(User author, Topic topic, String content) {
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    public Post(User author, Long regionId, Topic topic, String content) {
         this.author = author;
+        this.regionId = regionId;
         this.topic = topic;
         this.content = content;
     }

--- a/salgulok/src/main/java/com/salgulok/community/repository/CommentRepository.java
+++ b/salgulok/src/main/java/com/salgulok/community/repository/CommentRepository.java
@@ -2,6 +2,32 @@
 package com.salgulok.community.repository;
 
 import com.salgulok.community.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> { }
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Page<Comment> findByPostId(Long postId, Pageable pageable);
+    Optional<Comment> findByIdAndPostId(Long id, Long postId);
+
+    long countByPostId(Long postId);
+
+    interface CommentCount {
+        Long getPostId();
+        Long getCount();
+    }
+
+    @Query("""
+        select c.post.id as postId, count(c) as count
+        from Comment c
+        where c.post.id in :postIds
+        group by c.post.id
+    """)
+    List<CommentCount> countByPostIdIn(@Param("postIds") List<Long> postIds);
+}
+

--- a/salgulok/src/main/java/com/salgulok/community/service/CommunityService.java
+++ b/salgulok/src/main/java/com/salgulok/community/service/CommunityService.java
@@ -42,6 +42,16 @@ public class CommunityService {
         if ("STAYING".equalsIgnoreCase(cond.getStatus())) {
             spec = spec.and(PostSpecs.authorIsStaying());
         }
+
+        // ★ regionId 우선
+        if (cond.getRegionId() != null) {
+            spec = spec.and(PostSpecs.authorRegionIdEq(cond.getRegionId()));
+        } else if (StringUtils.hasText(cond.getRegion())) {
+            // 문자열로 넘어오면 접두 매칭(서울→서울%) 또는 정확매칭 중 택1
+            spec = spec.and(PostSpecs.authorRegionLike(cond.getRegion()));
+            // 정확 매칭 원하면: spec = spec.and(PostSpecs.authorRegionEq(cond.getRegion()));
+        }
+
         return postRepository.findAll(spec, pageable).map(PostResponse::from);
     }
 
@@ -55,7 +65,7 @@ public class CommunityService {
     public Long createPost(PostCreateRequest req) {
         User author = userRepository.findById(req.getAuthorId())
                 .orElseThrow(() -> new IllegalArgumentException("User not found: " + req.getAuthorId()));
-        Post post = new Post(author, req.getTopic(), req.getContent());
+        Post post = new Post(author, req.getRegionId(), req.getTopic(), req.getContent());
         return postRepository.save(post).getId();
     }
 
@@ -84,4 +94,21 @@ public class CommunityService {
         }
         commentRepository.delete(c);
     }
+
+    // service/CommunityService.java (추가 분)
+    public Page<CommentResponse> getComments(Long postId, Pageable pageable) {
+        return commentRepository.findByPostId(postId, pageable)
+                .map(CommentResponse::from);
+    }
+
+    public CommentResponse getComment(Long postId, Long commentId) {
+        Comment c = commentRepository.findByIdAndPostId(commentId, postId)
+                .orElseThrow(() -> new IllegalArgumentException("Comment not found: " + commentId));
+        return CommentResponse.from(c);
+    }
+
+
+
+
+
 }

--- a/salgulok/src/main/java/com/salgulok/community/spec/PostSpecs.java
+++ b/salgulok/src/main/java/com/salgulok/community/spec/PostSpecs.java
@@ -7,6 +7,7 @@ import com.salgulok.user.domain.User; // 실제 위치에 맞춰 import
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
 
 public class PostSpecs {
 
@@ -27,6 +28,27 @@ public class PostSpecs {
         return (root, query, cb) -> {
             Join<Post, User> author = root.join("author", JoinType.INNER);
             return cb.isTrue(author.get("isTraveling"));
+        };
+    }
+
+    // 작성자 지역 ID 또는 지역 이름으로 필터링
+    /** 작성자 지역(이름 접두 일치) - '서울', '경상' 등 */
+    public static Specification<Post> authorRegionLike(String key) {
+        return (root, query, cb) -> {
+            if (!StringUtils.hasText(key)) return cb.conjunction();
+            var region = root.join("author").join("region", JoinType.LEFT);
+            // regions.name이 '서울', '경상' 같은 짧은표기라고 가정
+            return cb.like(region.get("name"), key + "%");
+        };
+    }
+
+    /** 작성자 지역ID = 1..14 (숫자로 필터하고 싶을 때) */
+    public static Specification<Post> authorRegionIdEq(Long regionId) {
+        return (root, query, cb) -> {
+            if (regionId == null) return cb.conjunction();
+            var region = root.join("author").join("region", JoinType.LEFT);
+            // 컬럼명이 region_id → 엔티티 필드가 보통 'regionId' 혹은 'id'일 것. 실제 필드명에 맞춰 조정.
+            return cb.equal(region.get("regionId"), regionId);  // 또는 region.get("id")
         };
     }
 }


### PR DESCRIPTION
## 🍑 작업 개요
- 커뮤니티 게시글 엔티티에 `regionId` 필드를 추가하고, 관련 API 로직을 수정하여 지역 기반 게시글 생성 및 조회가 가능하도록 기능을 확장했습니다.

## 🚧 구현 중 겪은 이슈 및 해결 방법
- **이슈 1: JPA 엔티티와 DB 스키마 불일치로 인한 오류**
  - **문제:** `Post` 엔티티에 `regionId` 필드를 추가했지만, `posts` 테이블에 해당 컬럼이 없어 "Cannot resolve column" 에러가 발생했습니다.
  - **해결:** 데이터베이스 마이그레이션 도구나 `ddl-auto` 설정을 사용하여 `posts` 테이블에 `regionId` 컬럼을 추가했습니다.

- **이슈 2: 엔티티 생성자 로직 오류**
  - **문제:** `Post` 엔티티의 생성자에서 `regionId` 매개변수가 누락되어, `this.regionId = regionId;` 구문이 자기 자신에게 `null`을 할당하는 문제가 발생했습니다.
  - **해결:** `Post` 생성자에 `Long regionId` 매개변수를 추가하고, `communityService.createPost` 메서드에서 DTO의 `getRegionId()` 값을 올바르게 전달하도록 수정했습니다.

- **이슈 3: `GET` 요청 파라미터 불일치로 인한 빈 결과**
  - **문제:** Postman으로 `http://localhost:8080/community/posts?regionId=14` 요청을 보냈을 때, DB에 데이터가 있음에도 불구하고 빈 리스트가 반환되었습니다. 백엔드 컨트롤러의 `@RequestParam`이 `regionId`로 되어 있었음에도 불구하고 `region_id`로 요청해야만 정상적으로 필터링이 되는 현상을 발견했습니다.
  - **해결:** Spring의 기본 파라미터 바인딩 설정이나 DTO 처리 과정의 잠재적 문제로 판단, 일단 요청 URL을 백엔드에서 정상적으로 인식하는 `region_id=14`로 변경하여 테스트를 성공시켰습니다. 추후 코드 컨벤션 통일을 위해 파라미터 이름을 일관되게 `regionId`로 수정할 필요가 있습니다.

## 🔍 참고 사항
- 이번 작업을 통해 게시글 작성 시 지역 정보(`regionId`)가 함께 저장되도록 구조를 개선했습니다.
- 지역별 필터링 기능이 추가되어 사용자 경험을 향상시킬 수 있습니다.

## 🔗 관련 이슈
- (없음)