### PR TITLE
feat(image): /images/confirm API 단순화 및 템플릿 연결 시점 변경

### DIFF
--- a/salgulok/src/main/java/com/salgulok/image/dto/request/ImageConfirmRequest.java
+++ b/salgulok/src/main/java/com/salgulok/image/dto/request/ImageConfirmRequest.java
@@ -13,8 +13,6 @@ import java.util.List;
 @Getter
 public class ImageConfirmRequest {
 
-    private Long templateId; // 템플릿 이미지 연동 시 사용 (없으면 프로필/마이페이지 등으로 활용)
-
     @NotEmpty
     @Valid
     private List<Item> items;

--- a/salgulok/src/main/java/com/salgulok/logEntry/domain/TemplateImage.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/domain/TemplateImage.java
@@ -26,13 +26,22 @@ public class TemplateImage {
     private Template template;
 
     @Column(nullable = false)
+    private String objectKey;
+
     private String imageUrl;
+    private String fileName;
+    private String contentType;
+    private Long imageSize;
 
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public TemplateImage(Template template, String imageUrl) {
+    public TemplateImage(Template template, String objectKey, String imageUrl, String fileName, String contentType, Long imageSize) {
         this.template = template;
+        this.objectKey = objectKey;
         this.imageUrl = imageUrl;
+        this.fileName = fileName;
+        this.contentType = contentType;
+        this.imageSize = imageSize;
     }
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/request/TemplateCreateRequest.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/request/TemplateCreateRequest.java
@@ -24,6 +24,16 @@ public class TemplateCreateRequest {
     @NotNull(message = "별점은 필수입니다.")
     private Integer star;
 
-    /** 해당 장소에 업로드된 이미지 URL 리스트 */
-    private List<String> imageUrls;
+    /** 해당 장소에 업로드된 이미지 정보 리스트 */
+    private List<ImageRequest> images;
+
+    @Getter
+    public static class ImageRequest {
+        @NotNull
+        private String objectKey; // S3 객체 키
+        private String url; // CloudFront 등 최종 사용자에게 서빙될 URL
+        private String fileName;     // (선택) 원본 파일명
+        private String contentType;  // (선택)
+        private Long size;           // (선택)
+    }
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/request/TemplateUpdateRequest.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/request/TemplateUpdateRequest.java
@@ -1,47 +1,19 @@
 package com.salgulok.logEntry.dto.request;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.List;
 
 /**
  * 템플릿 하나의 수정 요청 정보
  * → 기존 템플릿 ID 기준으로 텍스트/별점/이미지 수정
  */
+@Getter
+@Setter
 public class TemplateUpdateRequest {
     private Long templateId;
     private String text;
     private int star;
-    private List<String> imageUrls;
-
-    // Getter, Setter
-    public Long getTemplateId() {
-        return templateId;
-    }
-
-    public void setTemplateId(Long templateId) {
-        this.templateId = templateId;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    public void setText(String text) {
-        this.text = text;
-    }
-
-    public int getStar() {
-        return star;
-    }
-
-    public void setStar(int star) {
-        this.star = star;
-    }
-
-    public List<String> getImageUrls() {
-        return imageUrls;
-    }
-
-    public void setImageUrls(List<String> imageUrls) {
-        this.imageUrls = imageUrls;
-    }
+    private List<TemplateCreateRequest.ImageRequest> images;
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/response/LogEntryDetailResponse.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/response/LogEntryDetailResponse.java
@@ -27,6 +27,7 @@ public class LogEntryDetailResponse {
     @Getter @Builder
     public static class ImageSummary {
         private Long imageId;
+        private String objectKey;
         private String imageUrl;
     }
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/service/LogEntryService.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/service/LogEntryService.java
@@ -63,11 +63,18 @@ public class LogEntryService {
 
         for (int i = 0; i < savedTemplates.size(); i++) {
             Template savedTemplate = savedTemplates.get(i);
-            List<String> imageUrls = request.getTemplates().get(i).getImageUrls();
+            List<TemplateCreateRequest.ImageRequest> imageRequests = request.getTemplates().get(i).getImages();
 
-            if (imageUrls != null && !imageUrls.isEmpty()) {
-                List<TemplateImage> images = imageUrls.stream()
-                        .map(url -> new TemplateImage(savedTemplate, url))
+            if (imageRequests != null && !imageRequests.isEmpty()) {
+                List<TemplateImage> images = imageRequests.stream()
+                        .map(imgReq -> new TemplateImage(
+                                savedTemplate,
+                                imgReq.getObjectKey(),
+                                imgReq.getUrl(),
+                                imgReq.getFileName(),
+                                imgReq.getContentType(),
+                                imgReq.getSize()
+                        ))
                         .collect(Collectors.toList());
                 templateImageRepository.saveAll(images);
             }
@@ -105,8 +112,17 @@ public class LogEntryService {
             affectedPlaceIds.add(template.getPlaceId());
 
             templateImageRepository.deleteAllByTemplate(template);
-            for (String imageUrl : templateReq.getImageUrls()) {
-                templateImageRepository.save(new TemplateImage(template, imageUrl));
+            if (templateReq.getImages() != null) {
+                for (TemplateCreateRequest.ImageRequest imgReq : templateReq.getImages()) {
+                    templateImageRepository.save(new TemplateImage(
+                            template,
+                            imgReq.getObjectKey(),
+                            imgReq.getUrl(),
+                            imgReq.getFileName(),
+                            imgReq.getContentType(),
+                            imgReq.getSize()
+                    ));
+                }
             }
         }
         for (Long pid : affectedPlaceIds) {
@@ -188,7 +204,7 @@ public class LogEntryService {
 
             String objectKey = templateImageRepository
                     .findFirstByTemplate_LogEntry_LogEntryIdOrderByTemplateImageIdAsc(e.getLogEntryId())
-                    .map(TemplateImage::getImageUrl)   // ← 컬럼은 imageUrl이지만 실제로 objectKey 저장 중
+                    .map(TemplateImage::getObjectKey)
                     .orElse(null);
 
             return LogEntryDateListResponse.Item.builder()
@@ -218,6 +234,7 @@ public class LogEntryService {
                     .images(imgs.stream().map(i ->
                             LogEntryDetailResponse.ImageSummary.builder()
                                     .imageId(i.getTemplateImageId())
+                                    .objectKey(i.getObjectKey())
                                     .imageUrl(i.getImageUrl())
                                     .build()
                     ).toList())


### PR DESCRIPTION
- /images/confirm API에서 templateId 제거
- 이제 API는 단순히 S3 업로드 성공만 확인
- 이미지-템플릿 연결 로직을 최종 저장 시점으로 이동
- 프론트엔드 로직 단순화 (업로드와 하루 기록 저장 분리)

## 🍑 작업 개요
- 구현한 기능을 요약하여 정리합니다.

## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항


## 🔗 관련 이슈
- (ex) closes #이슈번호
