### PR TITLE
[feat] paging시 현재 페이지 로그 개수 반환하도록

### DIFF
--- a/salgulok/src/main/java/com/salgulok/log/dto/response/LogPagingListResponse.java
+++ b/salgulok/src/main/java/com/salgulok/log/dto/response/LogPagingListResponse.java
@@ -14,10 +14,12 @@ public class LogPagingListResponse {
     private List<LogResponse> logs;
     private int totalPages;
     private int currentPage;
+    private int length;
 
     public LogPagingListResponse(Page<Log> page) {
         this.logs = page.stream().map(LogResponse::from).collect(Collectors.toList());
         this.totalPages = page.getTotalPages();
         this.currentPage = page.getNumber();
+        this.length = page.getNumberOfElements();
     }
 }


### PR DESCRIPTION
## 🍑 작업 개요
- paging시 현재 페이지 로그 개수 반환하도록

## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항


## 🔗 관련 이슈
- (ex) closes #이슈번호
