### PR TITLE
feat: 이미지 응답에 presignedUrl/objectKey 추가 및 createEntry 응답 개선

### DIFF
--- a/salgulok/src/main/java/com/salgulok/global/exception/ErrorCode.java
+++ b/salgulok/src/main/java/com/salgulok/global/exception/ErrorCode.java
@@ -27,10 +27,12 @@ public enum ErrorCode {
     INVALID_DATE_RANGE(400, "시작날짜는 종료일보다 이전이어야 합니다."),
 
     // logEntry
+    LOG_ENTRY_NOT_FOUND(404, "존재하는 하루 기록이 없습니다."),
     TEMPLATE_NOT_FOUND(404, "존재하는 템플릿이 없습니다."),
     PLACE_NOT_FOUND(404,"장소가 존재하지 않습니다" ),
     INVALID_REQUEST(400,"별점이 유효하지 않은 형식입니다"),
     LOG_ENTRY_NOT_IN_LOG(400, "해당 살구록에 존재하지 않는 하루 기록입니다."),
+
     // image
     IMAGE_NOT_FOUND(404, "존재하는 이미지가 없습니다.");
 

--- a/salgulok/src/main/java/com/salgulok/image/infra/ImageUrlResolver.java
+++ b/salgulok/src/main/java/com/salgulok/image/infra/ImageUrlResolver.java
@@ -3,6 +3,12 @@ package com.salgulok.image.infra;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.time.Duration;
 
 /**
  * 이미지 URL 해석기
@@ -13,6 +19,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ImageUrlResolver {
 
+    private final S3Presigner s3Presigner;
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
@@ -22,6 +30,8 @@ public class ImageUrlResolver {
     // CloudFront 도메인이 있다면 여기에 설정 (선택사항)
     @Value("${cloud.aws.cloudfront.domain:#{null}}")
     private String cloudfrontDomain;
+
+    private static final Duration PRESIGNED_URL_EXPIRY = Duration.ofHours(1);
 
     /**
      * objectKey를 기반으로 퍼블릭 URL 생성
@@ -55,5 +65,32 @@ public class ImageUrlResolver {
             return existingUrl;
         }
         return resolveUrl(objectKey);
+    }
+
+    /**
+     * objectKey를 기반으로 presigned GET URL 생성
+     * - S3 private 버킷에서 임시 접근 권한을 가진 URL 생성
+     * - 서명에 Content-Type을 포함하지 않음 (요구사항)
+     * 
+     * @param objectKey S3 객체 키
+     * @return presigned GET URL
+     */
+    public String createPresignedGetUrl(String objectKey) {
+        if (objectKey == null || objectKey.isBlank()) {
+            throw new IllegalArgumentException("objectKey cannot be null or blank");
+        }
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(PRESIGNED_URL_EXPIRY)
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+        return presignedRequest.url().toString();
     }
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/controller/LogEntryController.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/controller/LogEntryController.java
@@ -11,6 +11,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import com.salgulok.logEntry.dto.request.TemplateCreateRequest;
+import com.salgulok.logEntry.dto.response.LogEntryCreateResponse;
+import com.salgulok.logEntry.dto.response.TemplateCreateResponse;
 import java.net.URI;
 
 @RestController
@@ -21,14 +24,26 @@ public class LogEntryController {
     private final LogEntryService logEntryService;
 
     @PostMapping
-    public ResponseEntity<Void> createLogEntry(
+    public ResponseEntity<LogEntryCreateResponse> createLogEntry(
             @AuthenticationPrincipal User user,
             @PathVariable Long logId,
             @RequestBody @Valid LogEntryCreateRequest request
     ) {
-        Long entryId = logEntryService.createLogEntry(user, logId, request);
-        URI location = URI.create(String.format("/logs/%d/entries/%d", logId, entryId));
-        return ResponseEntity.created(location).build();
+        LogEntryCreateResponse response = logEntryService.createLogEntry(user, logId, request);
+        URI location = URI.create(String.format("/logs/%d/entries/%d", logId, response.getEntryId()));
+        return ResponseEntity.created(location).body(response);
+    }
+
+    @PostMapping("/{entryId}/templates")
+    public ResponseEntity<TemplateCreateResponse> addTemplateToEntry(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long logId,
+            @PathVariable Long entryId,
+            @RequestBody @Valid TemplateCreateRequest request
+    ) {
+        TemplateCreateResponse response = logEntryService.addTemplateToEntry(user, logId, entryId, request);
+        URI location = URI.create(String.format("/logs/%d/entries/%d/templates/%d", logId, entryId, response.getTemplateId()));
+        return ResponseEntity.created(location).body(response);
     }
 
     @PutMapping("/{entryId}")

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/request/TemplateCreateRequest.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/request/TemplateCreateRequest.java
@@ -2,39 +2,33 @@ package com.salgulok.logEntry.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
-/**
- * 장소별 템플릿 요청 DTO
- * - 하루 기록 내 여러 장소 각각의 글, 평점, 이미지 정보를 담는다
- */
 @Getter
-@NoArgsConstructor
+@Setter
 public class TemplateCreateRequest {
 
-    /** 장소 ID */
-    @NotNull(message = "placeId는 필수입니다.")
+    @NotNull(message = "장소 ID는 필수입니다.")
     private Long placeId;
 
     private String text;
 
-    /** 해당 장소에 대한 텍스트 기록 */
-    @NotNull(message = "별점은 필수입니다.")
     private Integer star;
 
-    /** 해당 장소에 업로드된 이미지 정보 리스트 */
-    private List<Long> imageIds;
-    private List<ImageRequest> images;
+    private List<Long> imageIds; // 우선순위 1
+
+    // 호환성을 위한 레거시 필드
+    private List<ImageRequest> images; // 우선순위 2
 
     @Getter
+    @Setter
     public static class ImageRequest {
-        @NotNull
-        private String objectKey; // S3 객체 키
-        private String url; // CloudFront 등 최종 사용자에게 서빙될 URL
-        private String fileName;     // (선택) 원본 파일명
-        private String contentType;  // (선택)
-        private Long size;           // (선택)
+        private String objectKey;
+        private String url;
+        private String fileName;
+        private String contentType;
+        private Long size;
     }
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/response/ImageInfo.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/response/ImageInfo.java
@@ -1,0 +1,24 @@
+package com.salgulok.logEntry.dto.response;
+
+import com.salgulok.image.infra.ImageUrlResolver;
+import com.salgulok.logEntry.domain.TemplateImage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ImageInfo {
+    private Long imageId;
+    private String objectKey;
+    private String imageUrl;
+    private String presignedUrl;
+
+    public static ImageInfo of(TemplateImage image, ImageUrlResolver resolver) {
+        return ImageInfo.builder()
+                .imageId(image.getTemplateImageId())
+                .objectKey(image.getObjectKey())
+                .imageUrl(image.getImageUrl())
+                .presignedUrl(resolver.createPresignedGetUrl(image.getObjectKey()))
+                .build();
+    }
+}

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/response/LogEntryCreateResponse.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/response/LogEntryCreateResponse.java
@@ -1,36 +1,15 @@
 package com.salgulok.logEntry.dto.response;
 
-import com.salgulok.logEntry.domain.LogEntry;
-import com.salgulok.logEntry.domain.Template;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class LogEntryCreateResponse {
     private Long entryId;
-    private List<TemplateInfo> templates;
-
-    @Getter
-    @Builder
-    public static class TemplateInfo {
-        private Long templateId;
-        private Long placeId;
-    }
-
-    // 정적 팩토리 메서드
-    public static LogEntryCreateResponse from(LogEntry logEntry, List<Template> templates) {
-        List<TemplateInfo> templateInfos = templates.stream()
-                .map(template -> TemplateInfo.builder()
-                        .templateId(template.getTemplateId())
-                        .placeId(template.getPlaceId())
-                        .build())
-                .collect(Collectors.toList());
-
-        return new LogEntryCreateResponse(logEntry.getLogEntryId(), templateInfos);
-    }
+    private LocalDate entryDate;
+    private List<TemplateResponse> templates;
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/response/LogEntryDetailResponse.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/response/LogEntryDetailResponse.java
@@ -31,5 +31,6 @@ public class LogEntryDetailResponse {
         private String objectKey;
         private String imageUrl;
         private String resolvedUrl; // 표준화된 URL (프론트는 이 값만 사용)
+        private String presignedUrl; // S3 private 버킷 접근용 presigned URL
     }
 }

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/response/TemplateCreateResponse.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/response/TemplateCreateResponse.java
@@ -1,0 +1,29 @@
+package com.salgulok.logEntry.dto.response;
+
+import com.salgulok.image.infra.ImageUrlResolver;
+import com.salgulok.logEntry.domain.Template;
+import com.salgulok.logEntry.domain.TemplateImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TemplateCreateResponse {
+    private Long templateId;
+    private Long placeId;
+    private String text;
+    private Integer star;
+    private List<ImageInfo> images;
+
+    public static TemplateCreateResponse of(Template template, List<TemplateImage> images, ImageUrlResolver resolver) {
+        return TemplateCreateResponse.builder()
+                .templateId(template.getTemplateId())
+                .placeId(template.getPlaceId())
+                .text(template.getText())
+                .star(template.getStar())
+                .images(images.stream().map(image -> ImageInfo.of(image, resolver)).toList())
+                .build();
+    }
+}

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/response/TemplateResponse.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/response/TemplateResponse.java
@@ -1,0 +1,29 @@
+package com.salgulok.logEntry.dto.response;
+
+import com.salgulok.image.infra.ImageUrlResolver;
+import com.salgulok.logEntry.domain.Template;
+import com.salgulok.logEntry.domain.TemplateImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class TemplateResponse {
+    private Long templateId;
+    private Long placeId;
+    private String text;
+    private Integer star;
+    private List<ImageInfo> images;
+
+    public static TemplateResponse of(Template template, List<TemplateImage> images, ImageUrlResolver resolver) {
+        return TemplateResponse.builder()
+                .templateId(template.getTemplateId())
+                .placeId(template.getPlaceId())
+                .text(template.getText())
+                .star(template.getStar())
+                .images(images.stream().map(image -> ImageInfo.of(image, resolver)).toList())
+                .build();
+    }
+}

--- a/salgulok/src/main/java/com/salgulok/logEntry/dto/response/TemplateUpdateResponse.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/dto/response/TemplateUpdateResponse.java
@@ -24,6 +24,7 @@ public class TemplateUpdateResponse {
         private String objectKey;
         private String imageUrl;
         private String resolvedUrl; // 표준화된 URL (프론트는 이 값만 사용)
+        private String presignedUrl; // S3 private 버킷 접근용 presigned URL
     }
 
     public static TemplateUpdateResponse of(Template t, List<TemplateImage> imgs) {
@@ -33,13 +34,14 @@ public class TemplateUpdateResponse {
                 .text(t.getText())
                 .star(t.getStar())
                 .images(imgs.stream().map(i -> {
-                    // resolvedUrl은 서비스에서 주입받아야 하므로 여기서는 null로 설정
+                    // resolvedUrl과 presignedUrl은 서비스에서 주입받아야 하므로 여기서는 null로 설정
                     // 실제 사용 시에는 서비스에서 ImageUrlResolver로 생성해서 주입
                     return ImageSummary.builder()
                             .imageId(i.getTemplateImageId())
                             .objectKey(i.getObjectKey())
                             .imageUrl(i.getImageUrl())
                             .resolvedUrl(null) // 서비스에서 주입 필요
+                            .presignedUrl(null) // 서비스에서 주입 필요
                             .build();
                 }).toList())
                 .build();
@@ -53,11 +55,13 @@ public class TemplateUpdateResponse {
                 .star(t.getStar())
                 .images(imgs.stream().map(i -> {
                     String resolvedUrl = urlResolver.resolveUrlOrDefault(i.getImageUrl(), i.getObjectKey());
+                    String presignedUrl = urlResolver.createPresignedGetUrl(i.getObjectKey());
                     return ImageSummary.builder()
                             .imageId(i.getTemplateImageId())
                             .objectKey(i.getObjectKey())
                             .imageUrl(i.getImageUrl())
                             .resolvedUrl(resolvedUrl)
+                            .presignedUrl(presignedUrl)
                             .build();
                 }).toList())
                 .build();

--- a/salgulok/src/main/java/com/salgulok/logEntry/service/LogEntryService.java
+++ b/salgulok/src/main/java/com/salgulok/logEntry/service/LogEntryService.java
@@ -45,7 +45,7 @@ public class LogEntryService {
     private final ImageUrlResolver imageUrlResolver;
 
     @Transactional
-    public Long createLogEntry(User user, Long logId, LogEntryCreateRequest request) {
+    public LogEntryCreateResponse createLogEntry(User user, Long logId, LogEntryCreateRequest request) {
         Log log = logRepository.findById(logId)
                 .orElseThrow(() -> new SalgulokException(ErrorCode.SALGULOG_NOT_FOUND));
 
@@ -67,7 +67,7 @@ public class LogEntryService {
 
         for (int i = 0; i < savedTemplates.size(); i++) {
             Template savedTemplate = savedTemplates.get(i);
-            TemplateCreateRequest tReq = request.getTemplates().get(i);
+            com.salgulok.logEntry.dto.request.TemplateCreateRequest tReq = request.getTemplates().get(i);
 
             // 1) 신규 권장: imageIds 기반 attach
             attachTemplateImagesByIds(user, savedTemplate, tReq.getImageIds());
@@ -88,7 +88,50 @@ public class LogEntryService {
         for (Long pid : affectedPlaceIds) {
             placeService.recalcAndUpdateRating(pid);
         }
-        return logEntry.getLogEntryId();
+
+        List<TemplateResponse> templateResponses = savedTemplates.stream()
+                .map(template -> {
+                    List<TemplateImage> images = templateImageRepository.findAllByTemplate_TemplateId(template.getTemplateId());
+                    return TemplateResponse.of(template, images, imageUrlResolver);
+                })
+                .collect(Collectors.toList());
+
+        return LogEntryCreateResponse.builder()
+                .entryId(logEntry.getLogEntryId())
+                .entryDate(logEntry.getEntryDate())
+                .templates(templateResponses)
+                .build();
+    }
+
+    @Transactional
+    public TemplateCreateResponse addTemplateToEntry(User user, Long logId, Long entryId, TemplateCreateRequest request) {
+        LogEntry logEntry = logEntryRepository.findById(entryId)
+                .orElseThrow(() -> new SalgulokException(ErrorCode.LOG_ENTRY_NOT_FOUND));
+
+        validateLogEntryOwnership(logId, logEntry);
+        // TODO: user 권한 검사
+
+        Template template = new Template(
+                logEntry,
+                request.getPlaceId(),
+                request.getText(),
+                request.getStar()
+        );
+        templateRepository.save(template);
+
+        // 1) 신규 권장: imageIds 기반 attach
+        attachTemplateImagesByIds(user, template, request.getImageIds());
+
+        // 2) 호환: 예전 images가 있으면 사용
+        if ((request.getImageIds() == null || request.getImageIds().isEmpty())
+                && request.getImages() != null && !request.getImages().isEmpty()) {
+            attachTemplateImagesLegacy(template, request.getImages());
+        }
+
+        placeService.recalcAndUpdateRating(template.getPlaceId());
+
+        List<TemplateImage> images = templateImageRepository.findAllByTemplate_TemplateId(template.getTemplateId());
+        return TemplateCreateResponse.of(template, images, imageUrlResolver);
     }
 
 
@@ -347,11 +390,13 @@ public class LogEntryService {
                     .star(t.getStar())
                     .images(imgs.stream().map(i -> {
                         String resolvedUrl = imageUrlResolver.resolveUrlOrDefault(i.getImageUrl(), i.getObjectKey());
+                        String presignedUrl = imageUrlResolver.createPresignedGetUrl(i.getObjectKey());
                         return LogEntryDetailResponse.ImageSummary.builder()
                                 .imageId(i.getTemplateImageId())
                                 .objectKey(i.getObjectKey())
                                 .imageUrl(i.getImageUrl())
                                 .resolvedUrl(resolvedUrl)
+                                .presignedUrl(presignedUrl)
                                 .build();
                     }).toList())
                     .build();

--- a/salgulok/src/main/java/com/salgulok/places/domain/Place.java
+++ b/salgulok/src/main/java/com/salgulok/places/domain/Place.java
@@ -33,10 +33,11 @@ public class Place{
     private String tel;
     private String overview;
 
-    @Column(name="star", nullable=false)
+    @Builder.Default
     private Double star =0.0;
 
-    @Column(name="star_count", nullable=false)
+    @Column(nullable = false)
+    @Builder.Default
     private Integer starCount=0;
 
     @Column(name = "region_id")


### PR DESCRIPTION
- 모든 이미지 응답에 presignedUrl 필드 추가
- objectKey 필드도 함께 제공 (프론트에서 presigned 재발급 가능)
- createEntry API 응답에 생성된 템플릿 정보 포함

## 🍑 작업 개요
- 구현한 기능을 요약하여 정리합니다.

## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항


## 🔗 관련 이슈
- (ex) closes #이슈번호
