### PR TITLE
feat: LogResponse에 isLiked 필드 추가 및 관련 API 응답 수정

### DIFF
--- a/salgulok/src/main/java/com/salgulok/community/entity/PostLike.java
+++ b/salgulok/src/main/java/com/salgulok/community/entity/PostLike.java
@@ -1,0 +1,46 @@
+package com.salgulok.community.entity;
+
+import com.salgulok.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@Table(
+        name = "post_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "ux_post_like_user_post", columnNames = {"user_id", "post_id"})
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+public class PostLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public PostLike(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+}

--- a/salgulok/src/main/java/com/salgulok/community/repository/PostLikeRepository.java
+++ b/salgulok/src/main/java/com/salgulok/community/repository/PostLikeRepository.java
@@ -1,0 +1,15 @@
+package com.salgulok.community.repository;
+
+import com.salgulok.community.entity.Post;
+import com.salgulok.community.entity.PostLike;
+import com.salgulok.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    Optional<PostLike> findByUserAndPost(User user, Post post);
+
+    long countByPost(Post post);
+}

--- a/salgulok/src/main/java/com/salgulok/global/exception/ErrorCode.java
+++ b/salgulok/src/main/java/com/salgulok/global/exception/ErrorCode.java
@@ -34,7 +34,11 @@ public enum ErrorCode {
     LOG_ENTRY_NOT_IN_LOG(400, "해당 살구록에 존재하지 않는 하루 기록입니다."),
 
     // image
-    IMAGE_NOT_FOUND(404, "존재하는 이미지가 없습니다.");
+    IMAGE_NOT_FOUND(404, "존재하는 이미지가 없습니다."),
+
+    // log like
+    ALREADY_LIKED_LOG(409, "이미 좋아요를 누른 기록입니다."),
+    LIKE_NOT_FOUND(404, "좋아요를 누르지 않은 기록입니다.");
 
 
     private final int status;

--- a/salgulok/src/main/java/com/salgulok/log/controller/LogController.java
+++ b/salgulok/src/main/java/com/salgulok/log/controller/LogController.java
@@ -76,31 +76,32 @@ public class LogController {
     // 살구록 검색 (키워드 검색/소팅/지역검색)
     @GetMapping("/search")
     public ResponseEntity<LogPagingListResponse> getLogs(
+            @AuthenticationPrincipal User user,
             @RequestParam(value = "keyword", required = false) String search,
             @RequestParam(value = "sort", defaultValue = "latest") String sort,
             @RequestParam(value = "regionId", defaultValue = "0") Long regionId,
             @RequestParam(value = "page", defaultValue = "0") int page
     ) {
-        LogPagingListResponse response = logService.getLogBySearchAndFiltering(search, sort, regionId, page);
+        LogPagingListResponse response = logService.getLogBySearchAndFiltering(search, sort, regionId, page, user);
         return ResponseEntity.ok(response);
     }
 
     // 전체 공개 살구록 리스트
     @GetMapping("/public")
-    public ResponseEntity<List<LogResponse>> getPublicLogs() {
-        return ResponseEntity.ok(logService.getPublicLogs());
+    public ResponseEntity<List<LogResponse>> getPublicLogs(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(logService.getPublicLogs(user));
     }
 
     // 내 살구록 리스트
     @GetMapping("/me")
     public ResponseEntity<List<LogResponse>> getMyLogs(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(logService.getLogsByUser(user.getUserId()));
+        return ResponseEntity.ok(logService.getLogsByUser(user.getUserId(), user));
     }
 
     // 특정 유저 살구록 리스트
     @GetMapping("/users/{userId}")
-    public ResponseEntity<List<LogResponse>> getUserLogs(@PathVariable Long userId) {
-        return ResponseEntity.ok(logService.getLogsByUser(userId));
+    public ResponseEntity<List<LogResponse>> getUserLogs(@AuthenticationPrincipal User user, @PathVariable Long userId) {
+        return ResponseEntity.ok(logService.getLogsByUser(userId, user));
     }
 
     // 특정 살구록 상세 조회 : 제목, 한줄평, 여행 시작일 및 종료일, 공개 여부, 여행 지역 ID, 대표 이미지 URL 모두 포함
@@ -141,8 +142,8 @@ public class LogController {
 
     // 로그 인기순 정렬 (프론트 실수 방지를 위해 공개 로그만 정렬함)
     @GetMapping("/popular")
-    public ResponseEntity<List<LogResponse>> getPopularLogs() {
-        return ResponseEntity.ok(logService.getPopularLogs());
+    public ResponseEntity<List<LogResponse>> getPopularLogs(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(logService.getPopularLogs(user));
     }
 
     @PatchMapping("/{logId}/upload")

--- a/salgulok/src/main/java/com/salgulok/log/domain/LogLike.java
+++ b/salgulok/src/main/java/com/salgulok/log/domain/LogLike.java
@@ -1,0 +1,48 @@
+package com.salgulok.log.domain;
+
+import com.salgulok.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@Table(
+        name = "log_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "ux_log_like_user_log", columnNames = {"user_id", "log_id"})
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+public class LogLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "log_id", nullable = false)
+    private Log log;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public LogLike(User user, Log log) {
+        this.user = user;
+        this.log = log;
+    }
+}
+
+

--- a/salgulok/src/main/java/com/salgulok/log/dto/response/LikeResponse.java
+++ b/salgulok/src/main/java/com/salgulok/log/dto/response/LikeResponse.java
@@ -1,0 +1,13 @@
+package com.salgulok.log.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeResponse {
+    private boolean liked;
+    private long likeCount;
+}
+
+

--- a/salgulok/src/main/java/com/salgulok/log/dto/response/LogPagingListResponse.java
+++ b/salgulok/src/main/java/com/salgulok/log/dto/response/LogPagingListResponse.java
@@ -16,8 +16,8 @@ public class LogPagingListResponse {
     private int currentPage;
     private int length;
 
-    public LogPagingListResponse(Page<Log> page) {
-        this.logs = page.stream().map(LogResponse::from).collect(Collectors.toList());
+    public LogPagingListResponse(Page<LogResponse> page) {
+        this.logs = page.getContent();
         this.totalPages = page.getTotalPages();
         this.currentPage = page.getNumber();
         this.length = page.getNumberOfElements();

--- a/salgulok/src/main/java/com/salgulok/log/dto/response/LogResponse.java
+++ b/salgulok/src/main/java/com/salgulok/log/dto/response/LogResponse.java
@@ -23,8 +23,9 @@ public class LogResponse {
     private Long likes;
     private Boolean isUpload;
     private Long ownerId;
+    private boolean isLiked;
 
-    public static LogResponse from(Log log){
+    public static LogResponse from(Log log, boolean isLiked){
         return LogResponse.builder()
                 .logId(log.getLogId())
                 .writer(log.getUser().getUsername())
@@ -39,6 +40,11 @@ public class LogResponse {
                 .likes(log.getLikes())
                 .isUpload(log.getIsUpload())
                 .ownerId(log.getUser().getUserId())
+                .isLiked(isLiked)
                 .build();
+    }
+
+    public static LogResponse from(Log log) {
+        return from(log, false);
     }
 }

--- a/salgulok/src/main/java/com/salgulok/log/repository/LogLikeRepository.java
+++ b/salgulok/src/main/java/com/salgulok/log/repository/LogLikeRepository.java
@@ -1,0 +1,19 @@
+package com.salgulok.log.repository;
+
+import com.salgulok.log.domain.Log;
+import com.salgulok.log.domain.LogLike;
+import com.salgulok.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LogLikeRepository extends JpaRepository<LogLike, Long> {
+
+    boolean existsByUserAndLog(User user, Log log);
+
+    Optional<LogLike> findByUserAndLog(User user, Log log);
+
+    long countByLog(Log log);
+}
+
+

--- a/salgulok/src/main/java/com/salgulok/log/service/LogService.java
+++ b/salgulok/src/main/java/com/salgulok/log/service/LogService.java
@@ -4,14 +4,14 @@ import com.salgulok.global.exception.ErrorCode;
 import com.salgulok.global.exception.SalgulokException;
 import com.salgulok.log.domain.Log;
 import com.salgulok.log.domain.LogComment;
-//import com.salgulok.log.dto.request.LogCheckRequest;
-//import com.salgulok.log.dto.request.LogCommentCreateRequest;
-//import com.salgulok.log.dto.request.LogCreateRequest;
-//import com.salgulok.log.dto.request.LogUpdateRequest;
+import com.salgulok.log.domain.LogLike;
+
 import com.salgulok.log.dto.request.*;
 import com.salgulok.log.dto.response.*;
 import com.salgulok.log.repository.LogCommentRepository;
+import com.salgulok.log.repository.LogLikeRepository;
 import com.salgulok.log.repository.LogRepository;
+
 import com.salgulok.region.domain.Region;
 import com.salgulok.region.repository.RegionRepository;
 import com.salgulok.user.domain.User;
@@ -31,6 +31,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LogService {
     private final LogRepository logRepository;
+    private final LogLikeRepository logLikeRepository;
     private final LogCommentRepository logCommentRepository;
     private final RegionRepository regionRepository;
     private static final int LogPage_paging_size = 4; // 추후 수정예정~ 일단 테스트로 4개만
@@ -60,14 +61,15 @@ public class LogService {
 
         Region updateRegion = findByRegionId(request.getRegionId());
         Log updateLog = log.updateLog(request, updateRegion);
-        return LogResponse.from(updateLog);
+        boolean isLiked = logLikeRepository.existsByUserAndLog(user, log);
+        return LogResponse.from(updateLog, isLiked);
     }
 
     @Transactional(readOnly = true)
     public LogPagingListResponse getMyLog(User user, int page) {
         Pageable pageable = PageRequest.of(page, LogPage_paging_size);
         Page<Log> logs = logRepository.findByUserOrderByCreatedAtDesc(user, pageable);
-        return new LogPagingListResponse(logs);
+        return new LogPagingListResponse(logs.map(log -> LogResponse.from(log, logLikeRepository.existsByUserAndLog(user, log))));
     }
 
     @Transactional(readOnly = true)
@@ -75,13 +77,13 @@ public class LogService {
         Region region = findByRegionId(id);
         List<Log> logs = logRepository.findByRegionAndIsPublicTrueAndIsUploadTrue(region);
         return new LogListResponse(logs.stream()
-                .map(LogResponse::from)
+                .map(log -> LogResponse.from(log, false)) // 로그인 안한 유저이므로 false
                 .collect(Collectors.toList()));
     }
 
     // 살구록 검색 (키워드 검색/소팅/지역검색)
     @Transactional(readOnly = true)
-    public LogPagingListResponse getLogBySearchAndFiltering(String search, String sort, Long regionId, int page) {
+    public LogPagingListResponse getLogBySearchAndFiltering(String search, String sort, Long regionId, int page, User user) {
         Sort sortOption;
 
         // 최신순, 조회순, 좋아요순 소팅
@@ -117,7 +119,10 @@ public class LogService {
             }
         }
 
-        return new LogPagingListResponse(logs);
+        return new LogPagingListResponse(logs.map(log -> {
+            boolean isLiked = user != null && logLikeRepository.existsByUserAndLog(user, log);
+            return LogResponse.from(log, isLiked);
+        }));
     }
 
 
@@ -144,9 +149,12 @@ public class LogService {
     }
 
     @Transactional(readOnly = true)
-    public List<LogResponse> getLogsByUser(Long userId) {
+    public List<LogResponse> getLogsByUser(Long userId, User currentUser) {
         return logRepository.findByUser_UserId(userId)
-                .stream().map(LogResponse::from).collect(Collectors.toList());
+                .stream().map(log -> {
+                    boolean isLiked = currentUser != null && logLikeRepository.existsByUserAndLog(currentUser, log);
+                    return LogResponse.from(log, isLiked);
+                }).collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -154,18 +162,19 @@ public class LogService {
         Log log = findByLogId(logId);
 
         // 본인 로그가 아니고 비공개면 접근 제한
-        if (!log.getIsPublic() && !log.getUser().getUserId().equals(user.getUserId())) {
+        if (!log.getIsPublic() && (user == null || !log.getUser().getUserId().equals(user.getUserId()))) {
             throw new SalgulokException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        return LogResponse.from(log);
+        boolean isLiked = user != null && logLikeRepository.existsByUserAndLog(user, log);
+        return LogResponse.from(log, isLiked);
     }
 
     @Transactional
     public void increaseViewCount(Long logId, User user) {
         Log log = findByLogId(logId);
         // 본인 글은 조회수 증가 안함
-        if (!log.getUser().getUserId().equals(user.getUserId())) {
+        if (user != null && !log.getUser().getUserId().equals(user.getUserId())) {
             log.increaseView();
         }
     }
@@ -189,18 +198,23 @@ public class LogService {
     @Transactional
     public void increaseLikeCount(Long logId, User user) {
         Log log = findByLogId(logId);
-        // 본인이 누를 수 없는 제약
-        if (!log.getUser().getUserId().equals(user.getUserId())) {
-            log.increaseLikes();
+        if (logLikeRepository.existsByUserAndLog(user, log)) {
+            throw new SalgulokException(ErrorCode.ALREADY_LIKED_LOG);
         }
+
+        LogLike logLike = new LogLike(user, log);
+        logLikeRepository.save(logLike);
+        log.increaseLikes();
     }
 
     @Transactional
     public void decreaseLikeCount(Long logId, User user) {
         Log log = findByLogId(logId);
-        if (!log.getUser().getUserId().equals(user.getUserId())) {
-            log.decreaseLikes();
-        }
+        LogLike logLike = logLikeRepository.findByUserAndLog(user, log)
+                .orElseThrow(() -> new SalgulokException(ErrorCode.LIKE_NOT_FOUND));
+
+        logLikeRepository.delete(logLike);
+        log.decreaseLikes();
     }
 
     @Transactional
@@ -217,16 +231,22 @@ public class LogService {
     }
 
     @Transactional(readOnly = true)
-    public List<LogResponse> getPublicLogs() {
+    public List<LogResponse> getPublicLogs(User user) {
         return logRepository.findByIsPublicTrueAndIsUploadTrueOrderByCreatedAtDesc()
-                .stream().map(LogResponse::from).toList();
+                .stream().map(log -> {
+                    boolean isLiked = user != null && logLikeRepository.existsByUserAndLog(user, log);
+                    return LogResponse.from(log, isLiked);
+                }).toList();
     }
 
     @Transactional(readOnly = true)
-    public List<LogResponse> getPopularLogs() {
+    public List<LogResponse> getPopularLogs(User user) {
         // ⚠ 기존 중복 메서드 제거: 이 메서드 단 하나만 유지
         return logRepository.findPopularPublicAndUploaded()
-                .stream().map(LogResponse::from).toList();
+                .stream().map(log -> {
+                    boolean isLiked = user != null && logLikeRepository.existsByUserAndLog(user, log);
+                    return LogResponse.from(log, isLiked);
+                }).toList();
     }
 
     @Transactional


### PR DESCRIPTION
- 로그 상세 조회 등 API 응답에 로그인 사용자 좋아요 여부(isLiked) 포함
- region 조회 API는 인증 미포함으로 항상 false 반환

## 🍑 작업 개요
- 구현한 기능을 요약하여 정리합니다.

## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항


## 🔗 관련 이슈
- (ex) closes #이슈번호
