### PR TITLE
feat: 로그 좋아요 여부 확인 API 추가

### DIFF
--- a/salgulok/src/main/java/com/salgulok/log/controller/LogController.java
+++ b/salgulok/src/main/java/com/salgulok/log/controller/LogController.java
@@ -140,6 +140,13 @@ public class LogController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/{logId}/is-liked")
+    public ResponseEntity<Boolean> isLiked(@AuthenticationPrincipal User user,
+                                           @PathVariable Long logId) {
+        boolean isLiked = logService.isLikedByUser(user, logId);
+        return ResponseEntity.ok(isLiked);
+    }
+
     // 로그 인기순 정렬 (프론트 실수 방지를 위해 공개 로그만 정렬함)
     @GetMapping("/popular")
     public ResponseEntity<List<LogResponse>> getPopularLogs(@AuthenticationPrincipal User user) {

--- a/salgulok/src/main/java/com/salgulok/log/service/LogService.java
+++ b/salgulok/src/main/java/com/salgulok/log/service/LogService.java
@@ -217,6 +217,15 @@ public class LogService {
         log.decreaseLikes();
     }
 
+    @Transactional(readOnly = true)
+    public boolean isLikedByUser(User user, Long logId) {
+        if (user == null) {
+            return false;
+        }
+        Log log = findByLogId(logId);
+        return logLikeRepository.existsByUserAndLog(user, log);
+    }
+
     @Transactional
     public void updateUploadStatus(User user, Long logId, Boolean isUpload) {
         Log log = findByLogId(logId);


### PR DESCRIPTION
- GET /logs/{logId}/is-liked 엔드포인트 신설
- 로그인 사용자가 해당 로그에 좋아요 눌렀는지 true/false 반환
- 기존 GET /logs/{logId}/likes는 총 개수 반환으로 유지

## 🍑 작업 개요
- 구현한 기능을 요약하여 정리합니다.

## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항


## 🔗 관련 이슈
- (ex) closes #이슈번호
